### PR TITLE
makes compatible with scala 2.11.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "continuum"
 
 version := "0.4-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.6"
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.1" % "provided"
 

--- a/src/main/scala/continuum/IntervalSet.scala
+++ b/src/main/scala/continuum/IntervalSet.scala
@@ -109,6 +109,8 @@ class IntervalSet[T <% Ordered[T]] private (tree: RB.Tree[Interval[T], Unit])
 
   override def iterator: Iterator[Interval[T]] = RB.keysIterator(tree)
 
+  override def keysIteratorFrom(start: Interval[T]): Iterator[Interval[T]] = RB.keysIterator(tree, Some(start))
+
   override def foreach[U](f: Interval[T] =>  U) = RB.foreachKey(tree, f)
 
   override def rangeImpl(from: Option[Interval[T]], until: Option[Interval[T]]): IntervalSet[T] = newSet(RB.rangeImpl(tree, from, until))


### PR DESCRIPTION
changes scala version from 2.10.3 to 2.11.6 in build.sbt
overrides keysIteratorFrom in IntervalSet
