### PR TITLE
made compatible with scala 2.11.8 and removed deprecated view bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,5 @@ scala:
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - oraclejdk6
-  - openjdk8
   - openjdk7
   - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: scala
 scala:
-  - "2.10.3"
+  - "2.11.8"
 jdk:
+  - oraclejdk8
   - oraclejdk7
+  - oraclejdk6
+  - openjdk8
   - openjdk7
   - openjdk6

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ name := "continuum"
 
 version := "0.4-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.8"
 
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.1" % "provided"
+libraryDependencies += "org.scalacheck" % "scalacheck_2.11" % "1.13.2" % "provided"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.0" % "test"

--- a/src/main/scala/continuum/Bound.scala
+++ b/src/main/scala/continuum/Bound.scala
@@ -10,7 +10,7 @@ package continuum
  * @tparam T type of values contained in the continuous, infinite, total-ordered set which the
  *           bound operates on.
  */
-sealed abstract class Bound[T <% Ordered[T]] {
+sealed abstract class Bound[T](implicit conv: T=>Ordered[T]) {
   /**
    * Returns `true` if all points below the other bound are also below this bound.
    */
@@ -34,12 +34,12 @@ sealed abstract class Bound[T <% Ordered[T]] {
   /**
    * Tranform this bound.
    */
-  def map[U <% Ordered[U]](f: T => U): Bound[U]
+  def map[U](f: T => U)(implicit conv: U=>Ordered[U]): Bound[U]
 }
 
 package bound {
 
-  case class Closed[T <% Ordered[T]](value: T) extends Bound[T] {
+  case class Closed[T](value: T)(implicit conv: T=>Ordered[T]) extends Bound[T] {
     override def isAbove(otherBound: Bound[T]): Boolean = otherBound match {
       case Open(otherC) => value >= otherC
       case Closed(otherC) => value >= otherC
@@ -54,10 +54,10 @@ package bound {
 
     override def isUnbounded: Boolean = false
 
-    def map[U <% Ordered[U]](f: (T) => U): Bound[U] = Closed(f(value))
+    def map[U](f: (T) => U)(implicit conv: U=>Ordered[U]): Bound[U] = Closed(f(value))
   }
 
-  case class Open[T <% Ordered[T]](value: T) extends Bound[T] {
+  case class Open[T](value: T)(implicit conv: T=>Ordered[T]) extends Bound[T] {
     override def isAbove(otherBound: Bound[T]): Boolean = otherBound match {
       case Open(otherC) => value >= otherC
       case Closed(otherC) => value > otherC
@@ -72,13 +72,13 @@ package bound {
 
     override def isUnbounded: Boolean = false
 
-    def map[U <% Ordered[U]](f: (T) => U): Bound[U] = Open(f(value))
+    def map[U](f: (T) => U)(implicit conv: U=>Ordered[U]): Bound[U] = Open(f(value))
   }
 
-  case class Unbounded[T <% Ordered[T]]() extends Bound[T] {
+  case class Unbounded[T]()(implicit conv: T=>Ordered[T]) extends Bound[T] {
     override def isBelow(other: Bound[T]): Boolean = true
     override def isAbove(other: Bound[T]): Boolean = true
     override def isUnbounded: Boolean = true
-    def map[U <% Ordered[U]](f: (T) => U): Bound[U] = Unbounded[U]()
+    def map[U](f: (T) => U)(implicit conv: U=>Ordered[U]): Bound[U] = Unbounded[U]()
   }
 }

--- a/src/main/scala/continuum/IntervalSet.scala
+++ b/src/main/scala/continuum/IntervalSet.scala
@@ -109,7 +109,10 @@ class IntervalSet[T](tree: RB.Tree[Interval[T], Unit])(implicit conv: T=>Ordered
 
   override def iterator: Iterator[Interval[T]] = RB.keysIterator(tree)
 
-  override def keysIteratorFrom(start: Interval[T]): Iterator[Interval[T]] = RB.keysIterator(tree, Some(start))
+  def keysIteratorFrom(start: Interval[T]): Iterator[Interval[T]] = {
+    val keys = RB.keysIterator(tree)
+    keys.drop(keys.indexOf(start))
+  }
 
   override def foreach[U](f: Interval[T] =>  U) = RB.foreachKey(tree, f)
 

--- a/src/main/scala/continuum/Ray.scala
+++ b/src/main/scala/continuum/Ray.scala
@@ -13,7 +13,7 @@ import continuum.bound.{Closed, Open, Unbounded}
  * @tparam T type of values contained in the continuous, infinite, total-ordered set which the
  *           ray operates on.
  */
-sealed abstract class Ray[T <% Ordered[T]] extends (T => Boolean) {
+sealed abstract class Ray[T](implicit conv: T => Ordered[T]) extends (T => Boolean) {
 
   def bound: Bound[T]
 
@@ -54,7 +54,7 @@ sealed abstract class Ray[T <% Ordered[T]] extends (T => Boolean) {
   def isSameDirection(other: Ray[T]): Boolean
 }
 
-case class GreaterRay[T <% Ordered[T]](bound: Bound[T]) extends Ray[T] with Ordered[GreaterRay[T]] {
+case class GreaterRay[T](bound: Bound[T])(implicit conv: T => Ordered[T]) extends Ray[T] with Ordered[GreaterRay[T]] {
 
   override def apply(point: T): Boolean = bound match {
     case Closed(value) => point >= value
@@ -114,7 +114,7 @@ case class GreaterRay[T <% Ordered[T]](bound: Bound[T]) extends Ray[T] with Orde
   }
 }
 
-case class LesserRay[T <% Ordered[T]](bound: Bound[T]) extends Ray[T] with Ordered[LesserRay[T]] {
+case class LesserRay[T](bound: Bound[T])(implicit conv: T => Ordered[T]) extends Ray[T] with Ordered[LesserRay[T]] {
 
   override def apply(point: T): Boolean = bound match {
     case Closed(value) => point <= value

--- a/src/main/scala/continuum/test/Generators.scala
+++ b/src/main/scala/continuum/test/Generators.scala
@@ -8,30 +8,30 @@ import continuum.{IntervalSet, Interval, Ray, Bound, LesserRay, GreaterRay}
 
 trait Generators {
 
-  implicit def arbOpenBound[T <% Ordered[T] : Arbitrary]: Arbitrary[Open[T]] =
+  implicit def arbOpenBound[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[Open[T]] =
     Arbitrary { for (cut <- arbitrary[T]) yield Open(cut) }
 
-  implicit def arbClosedBound[T <% Ordered[T] : Arbitrary]: Arbitrary[Closed[T]] =
+  implicit def arbClosedBound[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[Closed[T]] =
     Arbitrary { for (cut <- arbitrary[T]) yield Closed(cut) }
 
-  implicit def arbUnbounded[T <% Ordered[T]]: Arbitrary[Unbounded[T]] = Arbitrary(Unbounded[T]())
+  implicit def arbUnbounded[T](implicit conv: T => Ordered[T]): Arbitrary[Unbounded[T]] = Arbitrary(Unbounded[T]())
 
-  implicit def arbBound[T <% Ordered[T] : Arbitrary]: Arbitrary[Bound[T]] =
+  implicit def arbBound[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[Bound[T]] =
     Arbitrary(Gen.frequency(
       4 -> arbitrary[Closed[T]],
       4 -> arbitrary[Open[T]],
       1 -> arbitrary[Unbounded[T]]))
 
-  implicit def arbLesserRay[T <% Ordered[T] : Arbitrary]: Arbitrary[LesserRay[T]] =
+  implicit def arbLesserRay[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[LesserRay[T]] =
     Arbitrary(for (b <- arbitrary[Bound[T]]) yield LesserRay(b))
 
-  implicit def arbGreaterRay[T <% Ordered[T] : Arbitrary]: Arbitrary[GreaterRay[T]] =
+  implicit def arbGreaterRay[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[GreaterRay[T]] =
     Arbitrary(for (b <- arbitrary[Bound[T]]) yield GreaterRay(b))
 
-  implicit def arbRay[T <% Ordered[T] : Arbitrary]: Arbitrary[Ray[T]] =
+  implicit def arbRay[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[Ray[T]] =
       Arbitrary(Gen.oneOf(arbitrary[GreaterRay[T]], arbitrary[LesserRay[T]]))
 
-  implicit def arbInterval[T <% Ordered[T]: Arbitrary]: Arbitrary[Interval[T]] = Arbitrary {
+  implicit def arbInterval[T: Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[Interval[T]] = Arbitrary {
     def validate(a: Bound[T], b: Bound[T]) =
       Interval.validate(GreaterRay(a), LesserRay(b)) ||
       Interval.validate(GreaterRay(b), LesserRay(a))
@@ -77,7 +77,7 @@ trait Generators {
     } yield new Interval(lower, upper)
   }
 
-  implicit def shrinkGreaterRay[T <% Ordered[T] : Shrink]: Shrink[GreaterRay[T]] = Shrink { ray =>
+  implicit def shrinkGreaterRay[T : Shrink](implicit conv: T => Ordered[T]): Shrink[GreaterRay[T]] = Shrink { ray =>
     ray.bound match {
       case Closed(n)   => for (np <- Shrink.shrink(n)) yield GreaterRay(Closed(np))
       case Open(n)     => for (np <- Shrink.shrink(n)) yield GreaterRay(Open(np))
@@ -85,7 +85,7 @@ trait Generators {
     }
   }
 
-  implicit def shrinkLesserRay[T <% Ordered[T] : Shrink]: Shrink[LesserRay[T]] = Shrink { ray =>
+  implicit def shrinkLesserRay[T : Shrink](implicit conv: T => Ordered[T]): Shrink[LesserRay[T]] = Shrink { ray =>
     ray.bound match {
       case Closed(n)   => for (np <- Shrink.shrink(n)) yield LesserRay(Closed(np))
       case Open(n)     => for (np <- Shrink.shrink(n)) yield LesserRay(Open(np))
@@ -93,7 +93,7 @@ trait Generators {
     }
   }
 
-  implicit def shrinkInterval[T <% Ordered[T] : Shrink]: Shrink[Interval[T]] = Shrink { interval =>
+  implicit def shrinkInterval[T : Shrink](implicit conv: T => Ordered[T]): Shrink[Interval[T]] = Shrink { interval =>
     for {
       lower <- Shrink.shrink(interval.lower)
       upper <- Shrink.shrink(interval.upper) if Interval.validate(lower, upper)
@@ -161,7 +161,7 @@ trait Generators {
       1 -> unboundedOpen)
   }
 
-  implicit def arbIntervalSet[T <% Ordered[T] : Arbitrary]: Arbitrary[IntervalSet[T]] =
+  implicit def arbIntervalSet[T : Arbitrary](implicit conv: T => Ordered[T]): Arbitrary[IntervalSet[T]] =
     Arbitrary(for (intervals <- arbitrary[Array[Interval[T]]]) yield IntervalSet(intervals:_*))
 
   /**


### PR DESCRIPTION
Hi @danburkert , very nice work on the library!
I adapted it to Scala 2.11.8 and removed all instances of the deprecated view bounds. 

Comments are welcome.
